### PR TITLE
Feature/PP-38 Fixing "What I Do" Navigation Link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,7 +31,7 @@
             </div>
             <nav>
                 <section>
-                    <a href="#introduction">
+                    <a href="#">
                         <p class="active">What I Do</p>
                     </a>
                 


### PR DESCRIPTION
This feature PR updates the following:

- Change the "What I Do" navigation hyperlink `href` to instead link to the top of the page.