### PR TITLE
Feature/PP-20 Project Highlight Selection

### DIFF
--- a/public/assets/js/script.js
+++ b/public/assets/js/script.js
@@ -272,10 +272,13 @@ function switchHighlightedProject(event) {
     document.querySelector('#work .project-hightlight').style.opacity = 0;
     event.target.style.opacity = 0;
 
+    document.querySelector('#work .project-tiles').style.pointerEvents = 'none';
+
     setTimeout(() => {
         updatePreSelectedProjectDisplay(projects[newlySelectedId]);
         updateProjectTile(projects[currentlyHighlightedId], newlySelectedId);
         document.querySelector('#work .project-hightlight').style.opacity = 1;
         event.target.style.opacity = 1;
+        document.querySelector('#work .project-tiles').style.pointerEvents = 'all';
     }, 500);
 }

--- a/public/assets/js/script.js
+++ b/public/assets/js/script.js
@@ -240,6 +240,8 @@ function updatePreSelectedProjectDisplay(project) {
             document.querySelector('#work .project-hightlight .project-highlight-information .tech-used').insertAdjacentHTML("beforeend", techSVGCodes[tech]);
         }
     });
+
+    return 'done';
 }
 
 function updateProjectTile(project, tileId) {
@@ -263,10 +265,17 @@ function updateProjectTile(project, tileId) {
 
 
 function switchHighlightedProject(event) {
-    let newlySelectedId = event.target.dataset.projectId;
 
+    let newlySelectedId = event.target.dataset.projectId;
     let currentlyHighlightedId = document.querySelector('#work .project-hightlight').dataset.projectId;
 
-    updatePreSelectedProjectDisplay(projects[newlySelectedId]);
-    updateProjectTile(projects[currentlyHighlightedId], newlySelectedId);
+    document.querySelector('#work .project-hightlight').style.opacity = 0;
+    event.target.style.opacity = 0;
+
+    setTimeout(() => {
+        updatePreSelectedProjectDisplay(projects[newlySelectedId]);
+        updateProjectTile(projects[currentlyHighlightedId], newlySelectedId);
+        document.querySelector('#work .project-hightlight').style.opacity = 1;
+        event.target.style.opacity = 1;
+    }, 500);
 }

--- a/public/assets/js/script.js
+++ b/public/assets/js/script.js
@@ -39,6 +39,11 @@
         fetch("https://graphql.contentful.com/content/v1/spaces/i98swu3sb2vt/environments/master", fetchOptions) // Read-only API for Published Data
             .then(response => response.json())
             .then(data => {
+
+                if (data.data.portfolioWorkCollection.items.length === 0) {
+                    document.querySelector('#work .project-hightlight').innerHTML = `<h1>Projects coming soon...</h1>`;
+                }
+                
                 data.data.portfolioWorkCollection.items.forEach(item => {
                     if (item.preSelected) {
                         updatePreSelectedProjectDisplay(item);

--- a/public/assets/styles/style.css
+++ b/public/assets/styles/style.css
@@ -226,7 +226,8 @@ header nav > section {
     grid-area: highlight;
     display: flex;
     padding-left: 2em;
-    margin-bottom: 3em; }
+    margin-bottom: 3em;
+    transition: opacity 0.5s; }
     #work section:nth-of-type(1) .project-highlight-display {
       border-radius: 20px;
       overflow-y: scroll;
@@ -292,7 +293,8 @@ header nav > section {
     border-radius: 20px;
     overflow: hidden;
     cursor: pointer;
-    z-index: 1; }
+    z-index: 1;
+    transition: opacity 0.5s; }
     #work .project-tile img {
       width: 100%;
       pointer-events: none; }
@@ -323,6 +325,12 @@ header nav > section {
           fill: var(--accent-colour); }
         #work .project-tile .tech-used svg:first-of-type {
           padding: 0; }
+
+@keyframes fadeInOut {
+  50% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
 
 #contact {
   display: flex;

--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
         <section id="work">
             <h1>Project / Real World Work</h1>
 
-            <section class="project-hightlight" data-project-id="1">
+            <section class="project-hightlight">
                 <div class="project-highlight-display">
                     <img>
                 </div>

--- a/sass/partials/_work.scss
+++ b/sass/partials/_work.scss
@@ -21,10 +21,10 @@
  
     section:nth-of-type(1) {
         grid-area: highlight;
-
         display: flex;
         padding-left: 2em;
         margin-bottom: 3em;
+        transition: opacity 0.5s;
 
         .project-highlight-display {
             border-radius: 20px;
@@ -126,6 +126,7 @@
         overflow: hidden;
         cursor: pointer;
         z-index: 1;
+        transition: opacity 0.5s;
 
         img {
            width: 100%;
@@ -168,8 +169,16 @@
                     padding: 0;
                 }
             }
+        }
+    }
 
+    @keyframes fadeInOut {
+        50% {
+            opacity: 0;
         }
 
+        100% {
+            opacity: 1;
+        }
     }
 }


### PR DESCRIPTION
This feature PR updates the following:

- Adds a fading-in-out transition when switching highlighted portfolio project.
- Prevents the ability to click multiple project tiles during selection transition - this caused a bug that would lead to a project being displayed twice and overriding another project that wouldn't be viewable again without refreshing.