### PR TITLE
Hotfix/PP-47 Updating Image Path Names

### DIFF
--- a/public/assets/js/script.js
+++ b/public/assets/js/script.js
@@ -192,7 +192,7 @@
             root.style.setProperty('--main-nav-arrow', 'var(--' + scheme + '_main-nav-arrow)');
             root.style.setProperty('--accent-nav-arrow', 'var(--' + scheme + '_accent-nav-arrow)');
             
-            picture.src = '/public/assets/images/pictures/picture_' + scheme + '.png';
+            picture.src = '/assets/images/pictures/picture_' + scheme + '.png';
             body.dataset.currentColourScheme = scheme;
         }
 
@@ -206,7 +206,7 @@
             root.style.setProperty('--main-nav-arrow', 'var(--' + scheme + '_main-nav-arrow)');
             root.style.setProperty('--accent-nav-arrow', 'var(--' + scheme + '_accent-nav-arrow)');
             
-            picture.src = '/public/assets/images/pictures/picture_' + scheme + '.png';
+            picture.src = '/assets/images/pictures/picture_' + scheme + '.png';
         
             const oldScheme = body.dataset.currentColourScheme;
             event.target.dataset.scheme = oldScheme;

--- a/public/assets/styles/style.css
+++ b/public/assets/styles/style.css
@@ -7,18 +7,18 @@
   --p-t_main-colour: #6662D9;
   --p-t_accent-colour: #72FCDB;
   --p-t_opacity-colour: #6763d9cc;
-  --p-t_main-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_p-t_main.svg);
-  --p-t_accent-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_p-t_accent.svg);
+  --p-t_main-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_p-t_main.svg);
+  --p-t_accent-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_p-t_accent.svg);
   --o-b_main-colour: #FFAB34;
   --o-b_accent-colour: #84297E;
   --o-b_opacity-colour: #ffab34cc;
-  --o-b_main-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_o-b_main.svg);
-  --o-b_accent-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_o-b_accent.svg);
+  --o-b_main-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_o-b_main.svg);
+  --o-b_accent-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_o-b_accent.svg);
   --b-ng_main-colour: #0697B5;
   --b-ng_accent-colour: #9EF204;
   --b-ng_opacity-colour: #0697b5cc;
-  --b-ng_main-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_b-ng_main.svg);
-  --b-ng_accent-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_b-ng_accent.svg); }
+  --b-ng_main-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_b-ng_main.svg);
+  --b-ng_accent-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_b-ng_accent.svg); }
 
 html {
   scroll-behavior: smooth; }

--- a/public/index.html
+++ b/public/index.html
@@ -423,7 +423,7 @@
 
                 <aside>
                     <div id="picture-of-me">
-                        <img src="/public/assets/images/pictures/picture_p-t.png" alt="">
+                        <img src="/assets/images/pictures/picture_p-t.png" alt="">
                         <svg xmlns="http://www.w3.org/2000/svg" width="41.591" height="41.591" viewBox="0 0 41.591 41.591">
                             <circle cx="20.795" cy="20.795" r="20.795"/>
                         </svg>

--- a/sass/partials/_variables.scss
+++ b/sass/partials/_variables.scss
@@ -10,22 +10,22 @@
     --p-t_main-colour: #6662D9;
     --p-t_accent-colour: #72FCDB;
     --p-t_opacity-colour: #6763d9cc;
-    --p-t_main-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_p-t_main.svg);
-    --p-t_accent-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_p-t_accent.svg);
+    --p-t_main-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_p-t_main.svg);
+    --p-t_accent-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_p-t_accent.svg);
 
     // Orange / Burgundy Colour Scheme
     --o-b_main-colour: #FFAB34;
     --o-b_accent-colour: #84297E;
     --o-b_opacity-colour: #ffab34cc;
-    --o-b_main-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_o-b_main.svg);
-    --o-b_accent-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_o-b_accent.svg);
+    --o-b_main-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_o-b_main.svg);
+    --o-b_accent-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_o-b_accent.svg);
 
     // Blue / Neon Green Colour Scheme
     --b-ng_main-colour: #0697B5;
     --b-ng_accent-colour: #9EF204;
     --b-ng_opacity-colour: #0697b5cc;
-    --b-ng_main-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_b-ng_main.svg);
-    --b-ng_accent-nav-arrow: url(/public/assets/images/nav-arrows/nav-arrow_b-ng_accent.svg);
+    --b-ng_main-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_b-ng_main.svg);
+    --b-ng_accent-nav-arrow: url(/assets/images/nav-arrows/nav-arrow_b-ng_accent.svg);
 }
 
 // Fonts


### PR DESCRIPTION
Currently, Netlify-deployed site is giving a `404` error for every file image.

The solution is to update the paths of the image files to reflect the `public` directory being the root directory.