### PR TITLE
Hotfix/PP-48 Fix Mobile Footer

### DIFF
--- a/public/assets/styles/style.css
+++ b/public/assets/styles/style.css
@@ -476,7 +476,7 @@ footer {
   display: grid;
   grid-template-columns: 45% auto;
   align-items: stretch;
-  height: 100px;
+  height: 120px;
   position: relative;
   background-color: var(--main-colour); }
   footer > div {

--- a/sass/partials/_footer.scss
+++ b/sass/partials/_footer.scss
@@ -3,7 +3,7 @@ footer {
     display: grid;
     grid-template-columns: 45% auto;
     align-items: stretch;
-    height: 100px;
+    height: 120px;
     position: relative;
     background-color: var(--main-colour);
 


### PR DESCRIPTION
Currently the bottom of the “What I Do” SVG is showing under the footer. 

To solve I've increased the height of footer to fully cover the bottom of the page for mobile.